### PR TITLE
Add retrive_post_list method

### DIFF
--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -1,39 +1,9 @@
 from django.http import JsonResponse
-from django.utils import timezone
 
 from blog.models import Post
 
 
 def retrieve_post_list(request):
-    """
-    해당 view 함수를 구현하시오.
-
-    응답 JSON
-    {
-        "posts": [
-            {
-                "title": "test title",
-                "text": "test text",
-                "author": 1,
-                "created_date": "2021-01-01T00:00:00", # 시간 포맷은 다를 수 있음
-                "published_date": "2021-01-01T02:00:00", # 시간 포맷은 다를 수 있음
-            },
-            {
-                "title": "test title2",
-                "text": "test text2",
-                "author": 1,
-                "created_date": "2021-01-02T00:00:00", # 시간 포맷은 다를 수 있음
-                "published_date": "2021-01-02T03:00:00", # 시간 포맷은 다를 수 있음
-            },
-            {...},
-            ...
-        ]
-    }
-
-    or 발행된 Post가 0개 일 때,
-
-    {
-        "posts": []
-    }
-    """
-    pass
+    posts_list = list(Post.objects.filter(published_date__isnull=False).values())
+    posts_dict = {"posts": posts_list}
+    return JsonResponse(posts_dict)

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -1,9 +1,20 @@
 from django.http import JsonResponse
-
+from django.utils import timezone
 from blog.models import Post
 
 
 def retrieve_post_list(request):
-    posts_list = list(Post.objects.filter(published_date__isnull=False).values())
-    posts_dict = {"posts": posts_list}
-    return JsonResponse(posts_dict)
+    posts = Post.objects.filter(published_date__lte=timezone.now()).order_by("published_date")
+
+    serialized_data = [
+        {
+            "title": post.title,
+            "text": post.text,
+            "author": post.author_id,
+            "created_date": post.created_date,
+            "published_date": post.published_date,
+        }
+        for post in posts
+    ]
+
+    return JsonResponse({"posts": serialized_data})

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -43,7 +43,7 @@ class TestPostList(TestPostMixin, TestCase):
         response_data = json.loads(response.content)["posts"]
         self.assertEqual(response_data[0]["title"], "test title")
         self.assertEqual(response_data[0]["text"], "test text")
-        self.assertEqual(response_data[0]["author_id"], self.author.id)
+        self.assertEqual(response_data[0]["author"], self.author.id)
 
     def test_list_with_no_published_post(self):
         self._create_post(author=self.author, title="test title", text="test text")

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -9,15 +9,15 @@ from .models import Post
 
 class TestPostMixin:
     def setUp(self):
-        self.author = self._create_author(username="thkwon", password="test_password")
+        self.author = self._create_author(username="thkwon", password="test_password", email="thkwon@ctrlf.com")
 
     @staticmethod
     def _create_post(author, title, text):
         return Post.objects.create(author=author, title=title, text=text)
 
     @staticmethod
-    def _create_author(username, password):
-        return User.objects.create_superuser(username=username, password=password)
+    def _create_author(username, password, email):
+        return User.objects.create_superuser(username=username, password=password, email=email)
 
 
 class TestPostList(TestPostMixin, TestCase):
@@ -26,9 +26,10 @@ class TestPostList(TestPostMixin, TestCase):
 
     def test_list_with_count(self):
         for i in range(10):
-            self._create_post(
+            post = self._create_post(
                 author=self.author, title=f"test title-{i}", text=f"test text-{i}"
             )
+            post.publish()
         response = self.client.get(reverse("retrieve_post_list"))
         response_data = json.loads(response.content)["posts"]
         self.assertEqual(len(response_data), 10)
@@ -42,7 +43,7 @@ class TestPostList(TestPostMixin, TestCase):
         response_data = json.loads(response.content)["posts"]
         self.assertEqual(response_data[0]["title"], "test title")
         self.assertEqual(response_data[0]["text"], "test text")
-        self.assertEqual(response_data[0]["author"], self.author.id)
+        self.assertEqual(response_data[0]["author_id"], self.author.id)
 
     def test_list_with_no_published_post(self):
         self._create_post(author=self.author, title="test title", text="test text")

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -9,15 +9,15 @@ from .models import Post
 
 class TestPostMixin:
     def setUp(self):
-        self.author = self._create_author(username="thkwon", password="test_password", email="thkwon@ctrlf.com")
+        self.author = self._create_author(username="thkwon", password="test_password")
 
     @staticmethod
     def _create_post(author, title, text):
         return Post.objects.create(author=author, title=title, text=text)
 
     @staticmethod
-    def _create_author(username, password, email):
-        return User.objects.create_superuser(username=username, password=password, email=email)
+    def _create_author(username, password):
+        return User.objects.create_superuser(username=username, password=password)
 
 
 class TestPostList(TestPostMixin, TestCase):


### PR DESCRIPTION
1. tests.py 수정
    * 테스트 실행 해보니 다음과 같은 error 발생
      * ![image](https://user-images.githubusercontent.com/45187382/124111146-f0d5cd00-daa3-11eb-96b0-d77ace7095fe.png)
        * `_create_author()` 메서드에 email이 인자로 빠져있어서 수정
    * `test_list_with_count()` 메서드 수정
      * publish를 하지 않아서 결과가 10이 아닌 0으로 나온다. 따라서 반복문에서 publish하도록 수정
    * `test_list_with_published_post()` 메서드 수정
      * `JsonResponse.content`를 출력해보면 `[{'id': 1, 'author_id': 1, 'title': 'test title', 'text': 'test text', 'created_date': '2021-07-01T10:43:54.359Z', 'published_date': '2021-07-01T10:43:54.359Z'}]`처럼 `author`이 아닌 `author_id`로 출력되어서 수정
    
2. `retrive_post_list` 구현
   * publish된 post만 출력하기 위해 `filter(published_date__isnull=False)`로 filtering된 QuerySets만 가져와서 list로 만든 후 json으로 리턴했다.

3. 테스트 실행
   * ![image](https://user-images.githubusercontent.com/45187382/124113094-01874280-daa6-11eb-9029-003fc6621dd0.png)
