### PR TITLE
Jinho step2 remove post

### DIFF
--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/urls.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path("posts/<int:id>", views.retrieve_post_detail, name="retrieve_post_detail"),
     path("posts/create", views.create_post, name="create_post"),
     path("posts/<int:id>/put/update", views.update_post_with_put, name="update_post_with_put"),
+    path("posts/<int:id>/remove", views.remove_post_with_delete, name="remove_post_with_delete"),
 ]

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -1,8 +1,7 @@
 import json
-from http.client import NOT_FOUND, OK
+from http.client import NOT_FOUND, OK, UNAUTHORIZED
 
-from django.contrib.auth.models import User
-from django.http import JsonResponse, QueryDict
+from django.http import JsonResponse
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
@@ -87,3 +86,25 @@ def update_post_with_put(request, id):
 
     FYI, request.body 활용
     """
+
+
+@require_http_methods(["DELETE"])
+def remove_post_with_delete(request, id):
+    body = json.loads(request.body)
+    posts = Post.objects.filter(id=id)
+    if len(posts) == 0:
+        return JsonResponse({"message": "post를 찾을 수 없습니다."}, status=NOT_FOUND)
+
+    to_delete_post = posts[0]
+    if body["author"] != posts[0].author_id:
+        return JsonResponse({"message": "권한이 없습니다."}, status=UNAUTHORIZED)
+
+    to_delete_post.delete()
+    return JsonResponse(
+        {
+            "post":
+                {
+                    "title": to_delete_post.title,
+                    "text": to_delete_post.text,
+                }
+        }, status=OK)

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -91,12 +91,12 @@ def update_post_with_put(request, id):
 @require_http_methods(["DELETE"])
 def remove_post_with_delete(request, id):
     body = json.loads(request.body)
-    posts = Post.objects.filter(id=id)
-    if len(posts) == 0:
+    try:
+        to_delete_post = Post.objects.get(id=id)
+    except Post.DoesNotExist:
         return JsonResponse({"message": "post를 찾을 수 없습니다."}, status=NOT_FOUND)
 
-    to_delete_post = posts[0]
-    if body["author"] != posts[0].author_id:
+    if body["author"] != to_delete_post.author_id:
         return JsonResponse({"message": "권한이 없습니다."}, status=UNAUTHORIZED)
 
     to_delete_post.delete()

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -215,3 +215,19 @@ class TestPostRemove(TestPostMixin, TestCase):
         response = json.loads(response.content)
         self.assertEqual(response["message"], "post를 찾을 수 없습니다.")
 
+    def test_post_remove_with_error_about_author(self):
+        # Given: 유효하지 않은 author 생성
+        request_body = json.dumps({"author": 12314})
+
+        # When: 1번 post에 대한 remove API를 호출한다.
+        response = self.client.delete(reverse("remove_post_with_delete", kwargs={"id": self.post.id}),
+                                      data=request_body)
+
+        # Then: 상태코드는 401이고,
+        self.assertEqual(response.status_code, UNAUTHORIZED)
+        # And: 실제 post는 삭제되지 않는다.
+        self.assertEqual(Post.objects.all().count(), 1)
+
+        # And: 응답 메세지로 권한이 없습니다. 를 리턴한다.
+        response = json.loads(response.content)
+        self.assertEqual(response["message"], "권한이 없습니다.")

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -197,3 +197,21 @@ class TestPostRemove(TestPostMixin, TestCase):
         self.assertEqual(response["title"], "test title")
         self.assertEqual(response["text"], "test text")
 
+    def test_post_remove_with_error_about_post(self):
+        # Given: 유효하지 않은 post_id와 유효한 author를 생성
+        request_body = json.dumps({"author": self.author.id})
+        invalid_post_id = 837994
+
+        # When: 유효하지않은 post에 대한 remove API를 호출한다.
+        response = self.client.delete(reverse("remove_post_with_delete", kwargs={"id": invalid_post_id}),
+                                      data=request_body)
+
+        # Then: 상태코드는 404이고,
+        self.assertEqual(response.status_code, 404)
+        # And: 실제 post는 삭제되지 않는다.
+        self.assertEqual(Post.objects.all().count(), 1)
+
+        # And: 응답 메세지로 post를 찾을 수 없습니다. 를 리턴한다.
+        response = json.loads(response.content)
+        self.assertEqual(response["message"], "post를 찾을 수 없습니다.")
+

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -1,5 +1,5 @@
 import json
-from http.client import NOT_FOUND, OK
+from http.client import NOT_FOUND, OK, UNAUTHORIZED
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -173,3 +173,27 @@ class TestPostUpdate(TestPostMixin, TestCase):
         response = json.loads(response.content)
         # And: 응답 메세지로 post를 찾을 수 없습니다. 를 리턴 해야 한다.
         self.assertEqual(response["message"], "post를 찾을 수 없습니다.")
+
+class TestPostRemove(TestPostMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.post = Post.objects.create(author=self.author, title="test title", text="test text")
+
+    def test_post_remove_with_delete(self):
+        # Given: 삭제하기 위한 author를 담은 request_body를 생성
+        request_body = json.dumps({"author": self.author.id})
+
+        # When: 1번 post에 대한 remove API를 호출한다.
+        response = self.client.delete(reverse("remove_post_with_delete", kwargs={"id": self.post.id}),
+                                      data=request_body)
+
+        # Then: 상태코드는 200이고,
+        self.assertEqual(response.status_code, 200)
+        # And: 실제 post는 삭제된다.
+        self.assertEqual(Post.objects.all().count(), 0)
+
+        # And: 응답 값에서 삭제한 post의 title, text를 리턴한다.
+        response = json.loads(response.content)["post"]
+        self.assertEqual(response["title"], "test title")
+        self.assertEqual(response["text"], "test text")
+


### PR DESCRIPTION
1. 테스트 생성
   1. 유효한 `post_id`값과 post의 `author`와 request_body의 `author`이 같을 때 
          * 삭제 하고, 응답으로 삭제한 post의 제목과 내용을 리턴한다.
   2. `post_id`가 유효하지 않을 때
          * 삭제를 하지 않고, `post를 찾을 수 없습니다.`라는 메세지를 리턴한다.
   3. `post_id`는 유효하지만, post의 `author`와 request_body의 `author`이 다를 때 
          * 삭제를 하지 않고, `권한이 없습니다.`라는 메세지를 리턴한다.

2. 구현 코드 작성 

3. 테스트
   * ![image](https://user-images.githubusercontent.com/45187382/124577562-594bf200-de88-11eb-835a-ba5c329e2492.png)
   통과