### PR TITLE
Add Comment CRUD API

### DIFF
--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/urls.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 from . import views
 
-
 urlpatterns = [
     path("posts/", views.retrieve_post_list, name="retrieve_post_list"),
     path("posts/<int:id>", views.retrieve_post_detail, name="retrieve_post_detail"),
     path("posts/create", views.create_post, name="create_post"),
     path("posts/<int:id>/put/update", views.update_post_with_put, name="update_post_with_put"),
+    path("comments/create", views.create_comment_to_post, name="create_comment_to_post"),
 ]

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -1,12 +1,13 @@
 import json
-from http.client import NOT_FOUND, OK
+from http import HTTPStatus
 
 from django.contrib.auth.models import User
 from django.http import JsonResponse, QueryDict
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
-from blog.models import Post
+from blog.form import CommentForm
+from blog.models import Post, Comment
 
 
 def retrieve_post_list(request):
@@ -87,3 +88,24 @@ def update_post_with_put(request, id):
 
     FYI, request.body 활용
     """
+
+
+@require_http_methods(["POST"])
+def create_comment_to_post(request):
+    body = request.POST
+    comment_form = CommentForm(body)
+    if comment_form.is_valid():
+        comment = comment_form.save(commit=False)
+        comment.author = body["author"]
+        comment.post = Post.objects.get(id=body["post_id"])
+        comment.text = body["text"]
+        comment.save()
+        return JsonResponse({
+            "comment": {
+                "id": comment.id,
+                "author": comment.author,
+                "post_id": comment.post.id,
+                "text": comment.text,
+            }
+        }, status=HTTPStatus.CREATED)
+    return JsonResponse({"message": "form is invalid"}, status=HTTPStatus.BAD_REQUEST)

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/api/views.py
@@ -93,19 +93,24 @@ def update_post_with_put(request, id):
 @require_http_methods(["POST"])
 def create_comment_to_post(request):
     body = request.POST
-    comment_form = CommentForm(body)
-    if comment_form.is_valid():
-        comment = comment_form.save(commit=False)
-        comment.author = body["author"]
-        comment.post = Post.objects.get(id=body["post_id"])
-        comment.text = body["text"]
-        comment.save()
-        return JsonResponse({
-            "comment": {
-                "id": comment.id,
-                "author": comment.author,
-                "post_id": comment.post.id,
-                "text": comment.text,
-            }
-        }, status=HTTPStatus.CREATED)
+    try:
+        post_of_comment = Post.objects.get(id=body["post_id"])
+    except Post.DoesNotExist:
+        return JsonResponse({"message": "Post를 찾을 수 없습니다."}, status=HTTPStatus.NOT_FOUND)
+    else:
+        comment_form = CommentForm(body)
+        if comment_form.is_valid():
+            comment = comment_form.save(commit=False)
+            comment.author = body["author"]
+            comment.post = post_of_comment
+            comment.text = body["text"]
+            comment.save()
+            return JsonResponse({
+                "comment": {
+                    "id": comment.id,
+                    "author": comment.author,
+                    "post_id": comment.post.id,
+                    "text": comment.text,
+                }
+            }, status=HTTPStatus.CREATED)
     return JsonResponse({"message": "form is invalid"}, status=HTTPStatus.BAD_REQUEST)

--- a/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
+++ b/django_girls_tutorial/step2/jinho/djangogirls/blog/tests.py
@@ -197,3 +197,19 @@ class TestCommentCreate(TestPostMixin, TestCase):
         self.assertEqual(response["text"], "test comment")
         # And: post의 comment는 1개이다.
         self.assertEqual(Comment.objects.filter(post_id=self.post.id).count(), 1)
+
+    def test_create_comment_to_post_with_invalid_post(self):
+        # Given: request body에 유효하지 않은 post_id가 주어진다.
+        invalid_post_id = 369
+        request_body = {"author": "test by jinho", "post_id": invalid_post_id, "text": "test comment"}
+
+        # When: create_comment_to_post api를 호출
+        response = self.client.post(reverse("create_comment_to_post"), data=request_body)
+
+        # Then: 상태코드는 404이고
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        # And: 응답메세지로 "Post를 찾을 수 없습니다."를 리턴한다.
+        message = json.loads(response.content)["message"]
+        self.assertEqual(message, "Post를 찾을 수 없습니다.")
+        # And: comment는 추가되지 않으므로 개수는 0개이다.
+        self.assertEqual(Comment.objects.all().count(), 0)


### PR DESCRIPTION
1. 테스트 작성
     *  request body에 유효한 `author`, `post_id`, `text`가 있을경우 comment 작성 성공
     *  request body에 유효하지 않은 `post_id`,있을경우 comment 작성 실패

2. `urls.py`에 path 추가

3. `create_comment_to_post` 메서드 작성

-----

질문

1. `models.py`를 보면 Comment 클래스에 `author`은 `ForeignKey`가 아닌 `TextField`라서 테스트 작성시 `author`에 string으로 입력했는데 괜찮은지 모르겠습니다.

2. commit 작성시
     1. api 성공에 대한 테스트코드 작성 👉 commit
     2. 테스트가 통과하도록 메서드 작성 👉 commit
     3. api 실패에 대한 테스트코드 작성 👉 commit
     4. 모든 테스트가 통과하도록 메서드 수정 👉 commit
  
이런식으로 commit을 작성했는데, 이 방법이 맞는건지 아니면 api에 대한 테스트코드, 모든 테스트를 통과하는 메서드를 작성하여 하나의 commit으로 하는게 맞는건지 궁금합니다.

3. 제가 생각했을 때 Post와 Comment 관계가
![image](https://user-images.githubusercontent.com/45187382/125399146-24412180-e3eb-11eb-9293-c3f4e2e55022.png)
이런식으로 index가 post에 종속되어야 한다고 생각하는데, 코드를 작성하다보니
![image](https://user-images.githubusercontent.com/45187382/125399476-a2052d00-e3eb-11eb-99ff-6368999c1da8.png)
이런식으로 comment index가 post와 관계없이 작성한 순서에 따라 할당됩니다.
이것 때문에 계속 잘못된거 같은 생각이 드는데 어떻게 고쳐야할지 몰라서 질문드립니다.
