### PR TITLE
JH-18 Add api of checking nickname duplicate 

### DIFF
--- a/v2/src/ctrlf_auth/serializers.py
+++ b/v2/src/ctrlf_auth/serializers.py
@@ -72,3 +72,12 @@ class SendingAuthEmailSerializer(serializers.Serializer):
         except DjangoValidationError:
             raise DjangoValidationError("유효하지 않은 이메일 형식 입니다.")
         return email
+
+
+class NicknameDuplicateSerializer(serializers.Serializer):
+    data = serializers.CharField(max_length=30)
+
+    def validate_data(self, data):
+        if CtrlfUser.objects.filter(nickname=data).exists():
+            raise ValidationError("이미 존재하는 닉네임입니다.")
+        return data

--- a/v2/src/ctrlf_auth/urls.py
+++ b/v2/src/ctrlf_auth/urls.py
@@ -1,4 +1,9 @@
-from ctrlf_auth.views import LoginAPIView, SendingAuthEmailView, SignUpAPIView
+from ctrlf_auth.views import (
+    CheckNicknameDuplicateView,
+    LoginAPIView,
+    SendingAuthEmailView,
+    SignUpAPIView,
+)
 from django.urls import path
 
 app_name = "auth"
@@ -7,4 +12,5 @@ urlpatterns = [
     path("signup/", SignUpAPIView.as_view(), name="signup"),
     path("signup/email", SendingAuthEmailView.as_view(), name="sending_auth_email"),
     path("login/", LoginAPIView.as_view(), name="login"),
+    path("signup/nickname/duplicate", CheckNicknameDuplicateView.as_view(), name="check_nickname_duplicate"),
 ]

--- a/v2/src/ctrlf_auth/views.py
+++ b/v2/src/ctrlf_auth/views.py
@@ -2,6 +2,7 @@ from ctrlf_auth.helpers import generate_auth_code
 from ctrlf_auth.models import EmailAuthCode
 from ctrlf_auth.serializers import (
     LoginSerializer,
+    NicknameDuplicateSerializer,
     SendingAuthEmailSerializer,
     SignUpSerializer,
 )
@@ -58,4 +59,11 @@ class CheckNicknameDuplicateView(APIView):
     _SUCCESS_MSG = "사용 가능한 닉네임입니다."
 
     def get(self, request):
-        return Response(data={"message": self._SUCCESS_MSG}, status=status.HTTP_200_OK)
+        nickname = request.GET
+        serializer = NicknameDuplicateSerializer(data=nickname)
+        if serializer.is_valid():
+            return Response(data={"message": self._SUCCESS_MSG}, status=status.HTTP_200_OK)
+        else:
+            for _, message in serializer.errors.items():
+                message = message[0]
+        return Response(data={"message": message}, status=status.HTTP_400_BAD_REQUEST)

--- a/v2/src/ctrlf_auth/views.py
+++ b/v2/src/ctrlf_auth/views.py
@@ -60,7 +60,7 @@ class CheckNicknameDuplicateView(APIView):
 
     @swagger_auto_schema(query_serializer=NicknameDuplicateSerializer)
     def get(self, request):
-        nickname = request.GET
+        nickname = request.query_params
         serializer = NicknameDuplicateSerializer(data=nickname)
         if serializer.is_valid():
             return Response(data={"message": self._SUCCESS_MSG}, status=status.HTTP_200_OK)

--- a/v2/src/ctrlf_auth/views.py
+++ b/v2/src/ctrlf_auth/views.py
@@ -58,6 +58,7 @@ class SendingAuthEmailView(APIView):
 class CheckNicknameDuplicateView(APIView):
     _SUCCESS_MSG = "사용 가능한 닉네임입니다."
 
+    @swagger_auto_schema(query_serializer=NicknameDuplicateSerializer)
     def get(self, request):
         nickname = request.GET
         serializer = NicknameDuplicateSerializer(data=nickname)

--- a/v2/src/ctrlf_auth/views.py
+++ b/v2/src/ctrlf_auth/views.py
@@ -58,4 +58,4 @@ class CheckNicknameDuplicateView(APIView):
     _SUCCESS_MSG = "사용 가능한 닉네임입니다."
 
     def get(self, request):
-        return Response(status=status.HTTP_200_OK)
+        return Response(data={"message": self._SUCCESS_MSG}, status=status.HTTP_200_OK)

--- a/v2/src/ctrlf_auth/views.py
+++ b/v2/src/ctrlf_auth/views.py
@@ -13,7 +13,6 @@ from rest_framework_jwt.views import ObtainJSONWebToken
 
 
 class LoginAPIView(ObtainJSONWebToken):
-
     serializer_class = LoginSerializer
 
     @swagger_auto_schema(method="post")
@@ -53,3 +52,10 @@ class SendingAuthEmailView(APIView):
             for _, message in serializer.errors.items():
                 message = message[0]
         return Response(data={"message": message}, status=status.HTTP_400_BAD_REQUEST)
+
+
+class CheckNicknameDuplicateView(APIView):
+    _SUCCESS_MSG = "사용 가능한 닉네임입니다."
+
+    def get(self, request):
+        return Response(status=status.HTTP_200_OK)

--- a/v2/src/tests/test_auth.py
+++ b/v2/src/tests/test_auth.py
@@ -115,3 +115,21 @@ class TestGenerateAuthCode(TestCase):
         code = generate_auth_code()
         self.assertEqual(len(code), 8)
         self.assertRegexpMatches(code, "[a-zA-Z0-9]")
+
+
+class TestNicknameDuplicate(TestCase):
+    def setUp(self) -> None:
+        self.c = Client()
+
+    def _call_api(self, nickname):
+        return self.c.get(reverse("auth:check_nickname_duplicate"), {"data": nickname})
+
+    def test_check_nickname_duplicate_should_return_200_on_success(self):
+        # Given
+        valid_nickname = "test_nickname"
+
+        # When
+        response = self._call_api(valid_nickname)
+
+        # Then
+        self.assertEqual(response.status_code, 200)

--- a/v2/src/tests/test_auth.py
+++ b/v2/src/tests/test_auth.py
@@ -134,3 +134,15 @@ class TestNicknameDuplicate(TestCase):
         # Then
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["message"], "사용 가능한 닉네임입니다.")
+
+    def test_check_nickname_duplicate_should_return_400_on_duplicate_nickname(self):
+        # Given
+        CtrlfUser.objects.create(email="test123@naver.com", password="12345", nickname="test_nickname")
+        duplicate_nickname = "test_nickname"
+
+        # When
+        response = self._call_api(duplicate_nickname)
+
+        # Then
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["message"], "이미 존재하는 닉네임입니다.")

--- a/v2/src/tests/test_auth.py
+++ b/v2/src/tests/test_auth.py
@@ -4,6 +4,7 @@ from ctrlf_auth.helpers import generate_auth_code
 from ctrlf_auth.models import CtrlfUser, EmailAuthCode
 from django.test import Client, TestCase
 from django.urls import reverse
+from rest_framework import status
 
 
 class TestLogin(TestCase):
@@ -132,7 +133,7 @@ class TestNicknameDuplicate(TestCase):
         response = self._call_api(valid_nickname)
 
         # Then
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["message"], "사용 가능한 닉네임입니다.")
 
     def test_check_nickname_duplicate_should_return_400_on_duplicate_nickname(self):
@@ -144,5 +145,5 @@ class TestNicknameDuplicate(TestCase):
         response = self._call_api(duplicate_nickname)
 
         # Then
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["message"], "이미 존재하는 닉네임입니다.")

--- a/v2/src/tests/test_auth.py
+++ b/v2/src/tests/test_auth.py
@@ -133,3 +133,4 @@ class TestNicknameDuplicate(TestCase):
 
         # Then
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["message"], "사용 가능한 닉네임입니다.")

--- a/v2/src/tests/test_auth.py
+++ b/v2/src/tests/test_auth.py
@@ -126,24 +126,26 @@ class TestNicknameDuplicate(TestCase):
         return self.c.get(reverse("auth:check_nickname_duplicate"), {"data": nickname})
 
     def test_check_nickname_duplicate_should_return_200_on_success(self):
-        # Given
-        valid_nickname = "test_nickname"
+        # Given: 유효한 닉네임이 주어진다.
+        valid_nickname = "nickname"
 
-        # When
+        # When: check nickname duplicate api를 호출한다.
         response = self._call_api(valid_nickname)
 
-        # Then
+        # Then: status code 200을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # And: "사용 가능한 닉네임입니다."라는 메시지를 리턴한다.
         self.assertEqual(response.data["message"], "사용 가능한 닉네임입니다.")
 
     def test_check_nickname_duplicate_should_return_400_on_duplicate_nickname(self):
-        # Given
-        CtrlfUser.objects.create(email="test123@naver.com", password="12345", nickname="test_nickname")
-        duplicate_nickname = "test_nickname"
+        # Given: "test_nickname"이라는 닉네임을 가진 user와, 중복된 닉네임이 주어진다.
+        CtrlfUser.objects.create(email="test123@naver.com", password="12345", nickname="nickname")
+        duplicate_nickname = "nickname"
 
-        # When
+        # When: check nickname duplicate api를 호출한다.
         response = self._call_api(duplicate_nickname)
 
-        # Then
+        # Then: status code 400을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # And: "이미 존재하는 닉네임입니다."라는 메시지를 리턴한다.
         self.assertEqual(response.data["message"], "이미 존재하는 닉네임입니다.")


### PR DESCRIPTION
1. 인수 테스트 수정
    * Fail test에서 잘못된 값이 전달된 경우 400, 이미 존재하는 닉네임인 경우 404를 리턴 👉 이미 존재하는 닉네임인 경우 400을 리턴
    * 잘못된 값의 경우 처음에 Empty String으로 생각했는데 swagger에서 empty string으로 테스트가 안돼서 삭제
