### PR TITLE
JH-23: Add note create api

### DIFF
--- a/v2/src/ctrlf_auth/models.py
+++ b/v2/src/ctrlf_auth/models.py
@@ -24,7 +24,7 @@ class CtrlfUserManager(BaseUserManager):
 class CtrlfUser(AbstractBaseUser):
     email = models.EmailField(verbose_name="email address", max_length=255, unique=True, help_text="email 주소")
     is_active = models.BooleanField(default=True, help_text="패스워드")
-    nickname = models.CharField(max_length=30, default="nickname", help_text="닉네임")
+    nickname = models.CharField(max_length=30, help_text="닉네임")
 
     objects = CtrlfUserManager()
 

--- a/v2/src/ctrlf_auth/models.py
+++ b/v2/src/ctrlf_auth/models.py
@@ -24,7 +24,7 @@ class CtrlfUserManager(BaseUserManager):
 class CtrlfUser(AbstractBaseUser):
     email = models.EmailField(verbose_name="email address", max_length=255, unique=True, help_text="email 주소")
     is_active = models.BooleanField(default=True, help_text="패스워드")
-    nickname = models.CharField(max_length=30, help_text="닉네임")
+    nickname = models.CharField(max_length=30, default="nickname", help_text="닉네임")
 
     objects = CtrlfUserManager()
 

--- a/v2/src/ctrlfbe/note_urls.py
+++ b/v2/src/ctrlfbe/note_urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
-from .views import NoteAPIView, NoteDetailUpdateDeleteView, TopicListView
+from .views import NoteDetailUpdateDeleteView, NoteListView, TopicListView
 
 app_name = "notes"
 
 urlpatterns = [
-    path("", NoteAPIView.as_view(), name="retrieve_note_list"),
+    path("", NoteListView.as_view(), name="note_list_create"),
     path("<int:note_id>", NoteDetailUpdateDeleteView.as_view(), name="note_detail_update_delete"),
     path("<int:note_id>/topics", TopicListView.as_view(), name="topic_list"),
 ]

--- a/v2/src/ctrlfbe/note_urls.py
+++ b/v2/src/ctrlfbe/note_urls.py
@@ -1,11 +1,11 @@
 from django.urls import path
 
-from .views import NoteDetailUpdateDeleteView, NoteListView, TopicListView
+from .views import NoteDetailUpdateDeleteView, NoteListCreateView, TopicListView
 
 app_name = "notes"
 
 urlpatterns = [
-    path("", NoteListView.as_view(), name="note_list_create"),
+    path("", NoteListCreateView.as_view(), name="note_list_create"),
     path("<int:note_id>", NoteDetailUpdateDeleteView.as_view(), name="note_detail_update_delete"),
     path("<int:note_id>/topics", TopicListView.as_view(), name="topic_list"),
 ]

--- a/v2/src/ctrlfbe/serializers.py
+++ b/v2/src/ctrlfbe/serializers.py
@@ -1,18 +1,73 @@
+from ctrlf_auth.models import CtrlfUser
 from rest_framework import serializers
 
-from .models import Note, Page, Topic
+from .models import ContentRequest, Issue, Note, Page, Topic
 
 
 class NoteListSerializer(serializers.ListSerializer):
     pass
 
 
+class OwnerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CtrlfUser
+        exclude = ["password"]
+        extra_kwargs = {
+            "email": {"validators": [str]},
+        }
+
+
 class NoteSerializer(serializers.ModelSerializer):
+    owners = OwnerSerializer(many=True)
+
     class Meta:
         model = Note
         fields = "__all__"
         read_only_fields = ["id", "created_at"]
         list_serializer_class = NoteListSerializer
+
+    def create(self, validated_data):
+        owner_data = validated_data.pop("owners")
+        note = Note.objects.create(**validated_data)
+        note.owners.add(CtrlfUser.objects.get(email=owner_data[0].get("email")))
+        return note
+
+
+class ContentRequestSerializer(serializers.ModelSerializer):
+    user = OwnerSerializer()
+
+    class Meta:
+        model = ContentRequest
+        fields = "__all__"
+
+    def create(self, validated_data):
+        user_data = validated_data.pop("user")
+        user = CtrlfUser.objects.get(email=user_data.get("email"))
+        validated_data["user_id"] = user.id
+        content_request = ContentRequest.objects.create(**validated_data)
+
+        return content_request
+
+
+class IssueCreateSerializer(serializers.ModelSerializer):
+    owner = OwnerSerializer()
+    content_request = ContentRequestSerializer()
+
+    class Meta:
+        model = Issue
+        fields = "__all__"
+
+    def create(self, validated_data):
+        owner_data = validated_data.pop("owner")
+        owner = CtrlfUser.objects.get(email=owner_data.get("email"))
+
+        content_request_data = validated_data.pop("content_request")
+        content_request = ContentRequest.objects.get(sub_id=content_request_data.get("sub_id"))
+
+        validated_data["content_request"] = content_request
+        validated_data["owner_id"] = owner.id
+        issue = Issue.objects.create(**validated_data)
+        return issue
 
 
 class NoteListQuerySerializer(serializers.Serializer):

--- a/v2/src/ctrlfbe/serializers.py
+++ b/v2/src/ctrlfbe/serializers.py
@@ -36,9 +36,10 @@ class IssueCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         owner = validated_data.pop("owner")
+        note = validated_data.pop("note")
         content_request_data = {
             "user": owner,
-            "sub_id": Note.objects.count(),
+            "sub_id": note.id,
             "type": CtrlfContentType.NOTE,
             "action": CtrlfActionType.CREATE,
             "reason": "create note",
@@ -46,6 +47,11 @@ class IssueCreateSerializer(serializers.ModelSerializer):
         content_request = ContentRequest.objects.create(**content_request_data)
         issue = Issue.objects.create(owner=owner, content_request=content_request, **validated_data)
         return issue
+
+
+class NoteCreateRequestBodySerializer(serializers.Serializer):
+    title = serializers.CharField()
+    content = serializers.CharField()
 
 
 class NoteListQuerySerializer(serializers.Serializer):

--- a/v2/src/ctrlfbe/serializers.py
+++ b/v2/src/ctrlfbe/serializers.py
@@ -1,25 +1,21 @@
-from ctrlf_auth.models import CtrlfUser
 from rest_framework import serializers
 
-from .models import ContentRequest, Issue, Note, Page, Topic
+from .models import (
+    ContentRequest,
+    CtrlfActionType,
+    CtrlfContentType,
+    Issue,
+    Note,
+    Page,
+    Topic,
+)
 
 
 class NoteListSerializer(serializers.ListSerializer):
     pass
 
 
-class OwnerSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = CtrlfUser
-        exclude = ["password"]
-        extra_kwargs = {
-            "email": {"validators": [str]},
-        }
-
-
 class NoteSerializer(serializers.ModelSerializer):
-    owners = OwnerSerializer(many=True)
-
     class Meta:
         model = Note
         fields = "__all__"
@@ -27,46 +23,28 @@ class NoteSerializer(serializers.ModelSerializer):
         list_serializer_class = NoteListSerializer
 
     def create(self, validated_data):
-        owner_data = validated_data.pop("owners")
+        owner = validated_data.pop("owners")[0]
         note = Note.objects.create(**validated_data)
-        note.owners.add(CtrlfUser.objects.get(email=owner_data[0].get("email")))
+        note.owners.add(owner)
         return note
 
 
-class ContentRequestSerializer(serializers.ModelSerializer):
-    user = OwnerSerializer()
-
-    class Meta:
-        model = ContentRequest
-        fields = "__all__"
-
-    def create(self, validated_data):
-        user_data = validated_data.pop("user")
-        user = CtrlfUser.objects.get(email=user_data.get("email"))
-        validated_data["user_id"] = user.id
-        content_request = ContentRequest.objects.create(**validated_data)
-
-        return content_request
-
-
 class IssueCreateSerializer(serializers.ModelSerializer):
-    owner = OwnerSerializer()
-    content_request = ContentRequestSerializer()
-
     class Meta:
         model = Issue
         fields = "__all__"
 
     def create(self, validated_data):
-        owner_data = validated_data.pop("owner")
-        owner = CtrlfUser.objects.get(email=owner_data.get("email"))
-
-        content_request_data = validated_data.pop("content_request")
-        content_request = ContentRequest.objects.get(sub_id=content_request_data.get("sub_id"))
-
-        validated_data["content_request"] = content_request
-        validated_data["owner_id"] = owner.id
-        issue = Issue.objects.create(**validated_data)
+        owner = validated_data.pop("owner")
+        content_request_data = {
+            "user": owner,
+            "sub_id": Note.objects.count(),
+            "type": CtrlfContentType.NOTE,
+            "action": CtrlfActionType.CREATE,
+            "reason": "create note",
+        }
+        content_request = ContentRequest.objects.create(**content_request_data)
+        issue = Issue.objects.create(owner=owner, content_request=content_request, **validated_data)
         return issue
 
 

--- a/v2/src/ctrlfbe/views.py
+++ b/v2/src/ctrlfbe/views.py
@@ -17,6 +17,7 @@ from .constants import ERR_NOT_FOUND_MSG_MAP, ERR_UNEXPECTED, MAX_PRINTABLE_NOTE
 from .models import CtrlfIssueStatus, Note, Page, Topic
 from .serializers import (
     IssueCreateSerializer,
+    NoteCreateRequestBodySerializer,
     NoteSerializer,
     PageSerializer,
     TopicSerializer,
@@ -49,7 +50,7 @@ class BaseContentView(APIView):
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
-class NoteListView(APIView):
+class NoteListCreateView(APIView):
     authentication_classes = [
         CtrlfAuthentication,
     ]
@@ -65,7 +66,7 @@ class NoteListView(APIView):
             status=status.HTTP_200_OK,
         )
 
-    @swagger_auto_schema(query_serializer=NoteSerializer)
+    @swagger_auto_schema(request_body=NoteCreateRequestBodySerializer)
     def post(self, request, *args, **kwargs):
         note_data = {
             "title": request.data["title"],
@@ -81,8 +82,8 @@ class NoteListView(APIView):
         issue_serializer = IssueCreateSerializer(data=issue_data)
 
         if note_serializer.is_valid() and issue_serializer.is_valid():
-            note_serializer.save()
-            issue_serializer.save()
+            issue_serializer.save(note=note_serializer.save())
+
         else:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 

--- a/v2/src/ctrlfbe/views.py
+++ b/v2/src/ctrlfbe/views.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from ctrlf_auth.authentication import CtrlfAuthentication
 from ctrlfbe.swagger import (
     SWAGGER_NOTE_DETAIL_VIEW,
     SWAGGER_NOTE_LIST_VIEW,
@@ -43,8 +44,10 @@ class BaseContentView(APIView):
         return Response(data=serializer.data, status=status.HTTP_200_OK)
 
 
-class NoteAPIView(APIView):
-    authentication_classes: List[str] = []
+class NoteListView(APIView):
+    authentication_classes = [
+        CtrlfAuthentication,
+    ]
 
     @swagger_auto_schema(**SWAGGER_NOTE_LIST_VIEW)
     def get(self, request):

--- a/v2/src/ctrlfbe/views.py
+++ b/v2/src/ctrlfbe/views.py
@@ -83,6 +83,8 @@ class NoteListView(APIView):
         if note_serializer.is_valid() and issue_serializer.is_valid():
             note_serializer.save()
             issue_serializer.save()
+        else:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         return Response(status=status.HTTP_201_CREATED)
 

--- a/v2/src/ctrlfbe/views.py
+++ b/v2/src/ctrlfbe/views.py
@@ -14,19 +14,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .constants import ERR_NOT_FOUND_MSG_MAP, ERR_UNEXPECTED, MAX_PRINTABLE_NOTE_COUNT
-from .models import (
-    CtrlfActionType,
-    CtrlfContentType,
-    CtrlfIssueStatus,
-    Note,
-    Page,
-    Topic,
-)
+from .models import CtrlfIssueStatus, Note, Page, Topic
 from .serializers import (
-    ContentRequestSerializer,
     IssueCreateSerializer,
     NoteSerializer,
-    OwnerSerializer,
     PageSerializer,
     TopicSerializer,
 )
@@ -76,33 +67,21 @@ class NoteListView(APIView):
 
     @swagger_auto_schema(query_serializer=NoteSerializer)
     def post(self, request, *args, **kwargs):
-        user_serializer = OwnerSerializer(request.user)
-        note_data = {"title": request.data.get("title"), "owners": [user_serializer.data]}
-        note_serializer = NoteSerializer(data=note_data)
-
-        if note_serializer.is_valid():
-            note_serializer.save()
-
-        content_request_data = {
-            "user": user_serializer.data,
-            "sub_id": 1,
-            "type": CtrlfContentType.NOTE,
-            "reason": "create",
-            "action": CtrlfActionType.CREATE,
+        note_data = {
+            "title": request.data["title"],
+            "owners": [request.user.id],
         }
-        content_request_serializer = ContentRequestSerializer(data=content_request_data)
-        if content_request_serializer.is_valid():
-            content_request_serializer.save()
-
         issue_data = {
-            "title": request.data.get("title"),
-            "content": request.data.get("content"),
-            "owner": user_serializer.data,
+            "title": request.data["title"],
+            "content": request.data["content"],
+            "owner": request.user.id,
             "status": CtrlfIssueStatus.REQUESTED,
-            "content_request": content_request_serializer.data,
         }
+        note_serializer = NoteSerializer(data=note_data)
         issue_serializer = IssueCreateSerializer(data=issue_data)
-        if issue_serializer.is_valid():
+
+        if note_serializer.is_valid() and issue_serializer.is_valid():
+            note_serializer.save()
             issue_serializer.save()
 
         return Response(status=status.HTTP_201_CREATED)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -137,7 +137,7 @@ class TestNoteCreate(TestCase):
         self.assertEqual(Note.objects.count(), 0)
         self.assertEqual(Issue.objects.count(), 0)
 
-    def test_create_note_should_return_400_when_valid_title(self):
+    def test_create_note_should_return_400_when_invalid_title(self):
         # Given: invalid title과 content가 주어진다.
         invalid_title = ""
         request_body = {"title": invalid_title, "content": "test issue content"}

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -1,6 +1,6 @@
 from ctrlf_auth.models import CtrlfUser
 from ctrlf_auth.serializers import LoginSerializer
-from ctrlfbe.models import Note
+from ctrlfbe.models import Issue, Note
 from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -113,3 +113,13 @@ class TestNoteCreate(TestCase):
 
         # Then: status code는 201을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # And: Note가 정상적으로 생성된다.
+        note = Note.objects.all()[0]
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertEqual(note.title, "test note title")
+        self.assertEqual(note.owners.first().id, 1)
+        # And: Issue가 정상적으로 생성된다.
+        issue = Issue.objects.all()[0]
+        self.assertEqual(Issue.objects.count(), 1)
+        self.assertEqual(issue.content, "test issue content")
+        self.assertEqual(issue.owner_id, 1)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -152,3 +152,19 @@ class TestNoteCreate(TestCase):
         # And: Note와 Issue는 생성되지 않는다.
         self.assertEqual(Note.objects.count(), 0)
         self.assertEqual(Issue.objects.count(), 0)
+
+    def test_create_note_should_return_400_when_invalid_content(self):
+        # Given: title과 invalid content가 주어진다.
+        invalid_content = ""
+        request_body = {"title": "test title", "content": invalid_content}
+        # And: 로그인 해서 토큰을 발급받은 상황이다.
+        token = self._login()
+
+        # When: 인증이 필요한 create note api를 호출한다.
+        response = self._call_api(request_body, token)
+
+        # Then: status code는 400을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # And: Note와 Issue는 생성되지 않는다.
+        self.assertEqual(Note.objects.count(), 0)
+        self.assertEqual(Issue.objects.count(), 0)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -70,3 +70,28 @@ class TestNoteList(TestCase):
         self.assertEqual(response.data["next_cursor"], 0)
         # And: empty list를 리턴한다.
         self.assertEqual(len(response.data["notes"]), 0)
+
+
+class TestNoteCreate(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.data = {
+            "email": "test@test.com",
+            "password": "12345",
+        }
+        self.user = CtrlfUser.objects.create_user(**self.data)
+
+    def test_create_note_should_return_201(self):
+        # Given: note title과 issue 내용이 주어진다
+        request_body = {"title": "test note title", "content": "test issue content"}
+        # And: 회원가입된 user정보로 로그인을 해서 토큰을 발급받은 상황이다.
+        serializer = LoginSerializer()
+        serialized = serializer.validate(self.data)
+        token = serialized["token"]
+
+        # When: 인증이 필요한 create note api를 호출한다.
+        header = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+        response = self.client.post(reverse("notes:note_list_create"), request_body, **header)
+
+        # Then: status code는 201을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -9,17 +9,17 @@ from rest_framework import status
 class TestNoteList(TestCase):
     def setUp(self) -> None:
         self.client = Client()
-        self.data = {
+        self.user_data = {
             "email": "test@test.com",
             "password": "12345",
         }
-        self.user = CtrlfUser.objects.create_user(**self.data)
-        serializer = LoginSerializer()
-        serialized = serializer.validate(self.data)
-        self.token = serialized["token"]
+        self.user = CtrlfUser.objects.create_user(**self.user_data)
 
-    def _call_api(self, cursor):
-        header = {"HTTP_AUTHORIZATION": f"Bearer {self.token}"}
+    def _call_api(self, cursor, token=None):
+        if token:
+            header = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+        else:
+            header = {}
         return self.client.get(reverse("notes:note_list_create"), {"cursor": cursor}, **header)
 
     def _make_notes(self, count):
@@ -27,13 +27,19 @@ class TestNoteList(TestCase):
             note = Note.objects.create(title=f"test title {i}")
             note.owners.add(self.user)
 
+    def _login(self):
+        serializer = LoginSerializer()
+        return serializer.validate(self.user_data)["token"]
+
     def test_retrieve_note_list_should_return_200(self):
         # Given: 미리 30개의 노트를 생성하고, 시작 cursor가 주어진다.
         self._make_notes(30)
         given_cursor = 0
+        # And: 로그인해서 토큰을 발급받은 상황이다.
+        token = self._login()
 
         # When: retrieve note list api를 호출한다.
-        response = self._call_api(given_cursor)
+        response = self._call_api(given_cursor, token)
 
         # Then: status code 200을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -46,9 +52,11 @@ class TestNoteList(TestCase):
         # Given: 10개의 note를 생성하고 시작 cursor를 0으로 주어진다.
         self._make_notes(10)
         given_cursor = 3
+        # And: 로그인해서 토큰을 발급 받은 상황이다.
+        token = self._login()
 
         # When: retrieve note list api를 호출한다.
-        response = self._call_api(given_cursor)
+        response = self._call_api(given_cursor, token)
 
         # Then: status code는 200을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -60,9 +68,11 @@ class TestNoteList(TestCase):
     def test_retrieve_note_list_on_no_note(self):
         # Given: 노트 생성 없이, cursor만 주어진다.
         given_cursor = 0
+        # And: 로그인해서 토큰을 발급받은 상황이다.
+        token = self._login()
 
         # When: retrieve note list api를 호풀한다.
-        response = self._call_api(given_cursor)
+        response = self._call_api(given_cursor, token)
 
         # Then: status code는 200을 리턴한다
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -95,7 +95,7 @@ class TestNoteCreate(TestCase):
         serializer = LoginSerializer()
         return serializer.validate(self.data)["token"]
 
-    def _call_api(self, request_body, token):
+    def _call_api(self, request_body, token=None):
         if token:
             header = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
         else:
@@ -123,3 +123,16 @@ class TestNoteCreate(TestCase):
         self.assertEqual(Issue.objects.count(), 1)
         self.assertEqual(issue.content, "test issue content")
         self.assertEqual(issue.owner_id, 1)
+
+    def test_create_note_should_return_401_when_not_login(self):
+        # Given: note title과 issue 내용이 주어진다, 로그인은 하지 않는다.
+        request_body = {"title": "test note title", "content": "test issue content"}
+
+        # When: 인증이 필요한 create note api를 호출한다.
+        response = self._call_api(request_body)
+
+        # Then: status code는 401을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # And: Note와 Issue는 생성되지 않는다.
+        self.assertEqual(Note.objects.count(), 0)
+        self.assertEqual(Issue.objects.count(), 0)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -91,17 +91,25 @@ class TestNoteCreate(TestCase):
         }
         self.user = CtrlfUser.objects.create_user(**self.data)
 
+    def _login(self):
+        serializer = LoginSerializer()
+        return serializer.validate(self.data)["token"]
+
+    def _call_api(self, request_body, token):
+        if token:
+            header = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+        else:
+            header = {}
+        return self.client.post(reverse("notes:note_list_create"), request_body, **header)
+
     def test_create_note_should_return_201(self):
         # Given: note title과 issue 내용이 주어진다
         request_body = {"title": "test note title", "content": "test issue content"}
         # And: 회원가입된 user정보로 로그인을 해서 토큰을 발급받은 상황이다.
-        serializer = LoginSerializer()
-        serialized = serializer.validate(self.data)
-        token = serialized["token"]
+        token = self._login()
 
         # When: 인증이 필요한 create note api를 호출한다.
-        header = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
-        response = self.client.post(reverse("notes:note_list_create"), request_body, **header)
+        response = self._call_api(request_body, token)
 
         # Then: status code는 201을 리턴한다.
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/v2/src/tests/test_note.py
+++ b/v2/src/tests/test_note.py
@@ -136,3 +136,19 @@ class TestNoteCreate(TestCase):
         # And: Note와 Issue는 생성되지 않는다.
         self.assertEqual(Note.objects.count(), 0)
         self.assertEqual(Issue.objects.count(), 0)
+
+    def test_create_note_should_return_400_when_valid_title(self):
+        # Given: invalid title과 content가 주어진다.
+        invalid_title = ""
+        request_body = {"title": invalid_title, "content": "test issue content"}
+        # And: 로그인 해서 토큰을 발급받은 상황이다.
+        token = self._login()
+
+        # When: 인증이 필요한 create note api를 호출한다.
+        response = self._call_api(request_body, token)
+
+        # Then: status code는 400을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # And: Note와 Issue는 생성되지 않는다.
+        self.assertEqual(Note.objects.count(), 0)
+        self.assertEqual(Issue.objects.count(), 0)


### PR DESCRIPTION
늦어서 죄송합니다..

코드 작성하다가 도저히 모르겠어서 질문드립니다 ㅜ 

1. Note Create와 List의 URI가 같아서 하나의 클래스로 구현했습니다.(NoteListApi)
     note list는 get() 메서드를, create는 post() 메서드로 구현했는데,
     list의 경우는 authentication이 필요없고, create는 필요한데, 두 메서드 다르게 authentication_classes를 적용하고싶은데 방법을 모르겠습니다.. 그래서 일단은 note list에도 login후 header에 token을 담아서 get 요청을 보내는것으로 수정했습니다.

2. new Note를 생성할때, serializer에 현재 로그인한 user 정보와, title, content를 보냈는데, 계속 validated_data에 user정보가 나오지 않았습니다. 그래서 찾아보니까
  `{'owners': {'non_field_errors': [ErrorDetail(string='Expected a list of items but got type "dict".', code='not_a_list')]}}` 라고 이미 있는 email이라는 error 메세지가 나왔습니다.
user를 생성하는게 아니라 note에 login한 user를 추가해주려는것인데, 계속 이미 있는 email이라고해서 임시방편으로 `extra_kwargs = {"email": {"validators": []},}` 를 추가해 주었는데, 해결방법을 도저히 모르겠습니다

3. 마찬가지로 new Note를 생성하면 Issue도 생성해야하고 Issue 내부에 ContentRequest도 새로 생성하도록 임시로 만들긴했는데.. 이부분도 잘 모르겠습니다.

최대한 빠르게 api 작성하고 다른 작업하려고했는데 너무 막혀서 늦었습니다 죄송합니다..