### PR TITLE
JH-149: Add issue list api

### DIFF
--- a/v2/src/config/urls.py
+++ b/v2/src/config/urls.py
@@ -18,7 +18,6 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
-
 urlpatterns = [
     path("", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     path("admin/", admin.site.urls),
@@ -26,4 +25,5 @@ urlpatterns = [
     path("api/notes/", include("ctrlfbe.note_urls"), name="notes"),
     path("api/topics/", include("ctrlfbe.topic_urls"), name="topics"),
     path("api/pages/", include("ctrlfbe.page_urls"), name="pages"),
+    path("api/issues/", include("ctrlfbe.issue_urls"), name="issues"),
 ]

--- a/v2/src/ctrlfbe/issue_urls.py
+++ b/v2/src/ctrlfbe/issue_urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import IssueListView
+
+app_name = "issues"
+
+urlpatterns = [
+    path("", IssueListView.as_view(), name="issue_list"),
+]

--- a/v2/src/ctrlfbe/serializers.py
+++ b/v2/src/ctrlfbe/serializers.py
@@ -70,3 +70,11 @@ class PageSerializer(serializers.ModelSerializer):
         model = Page
         fields = "__all__"
         read_only_fields = ["id", "created_at"]
+
+
+class IssueSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    owner = serializers.EmailField()
+    title = serializers.CharField()
+    content = serializers.CharField()
+    status = serializers.CharField()

--- a/v2/src/ctrlfbe/views.py
+++ b/v2/src/ctrlfbe/views.py
@@ -135,3 +135,8 @@ class PageDetailUpdateDeleteView(BaseContentView):
     @swagger_auto_schema(**SWAGGER_PAGE_DETAIL_VIEW)
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
+
+
+class IssueListView(APIView):
+    def get(self, request, *args, **kwargs):
+        return Response(status=status.HTTP_200_OK)

--- a/v2/src/tests/test_issues.py
+++ b/v2/src/tests/test_issues.py
@@ -1,0 +1,74 @@
+from ctrlf_auth.models import CtrlfUser
+from ctrlfbe.models import CtrlfIssueStatus, Issue
+from django.test import Client, TestCase
+from django.urls import reverse
+from rest_framework import status
+
+
+class TestIssueList(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user_data = {
+            "email": "test@test.com",
+            "password": "12345",
+        }
+        self.user = CtrlfUser.objects.create_user(**self.user_data)
+
+    def _call_api(self, cursor):
+        return self.client.get(
+            reverse("issues:issue_list"),
+            {"cursor": cursor},
+        )
+
+    def _make_issues(self, count):
+        for i in range(1, count + 1):
+            Issue.objects.create(
+                owner=self.user,
+                title=f"test title {i}",
+                content=f"test content {1}",
+                status=CtrlfIssueStatus.REQUESTED,
+            )
+
+    def test_issue_list_should_return_200(self):
+        # Given: 미리 30개의 이슈를 생성하고, 시작 cursor가 주어진다.
+        self._make_issues(30)
+        given_cursor = 0
+
+        # When: issue list api를 호출한다.
+        response = self._call_api(given_cursor)
+
+        # Then: status code 200을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # And: next_cursor는 30을 리턴한다.
+        self.assertEqual(response.data["next_cursor"], 30)
+        # And: 시작 cursor부터 30개의 issue list를 리턴한다.
+        self.assertEqual(len(response.data["issues"]), 30)
+
+    def test_issue_list_on_issue_count_less_than_30(self):
+        # Given: 10개의 이슈를 생성하고 시작 cursor를 3으로 주어진다.
+        self._make_issues(10)
+        given_cursor = 3
+
+        # When: issue list api를 호출한다.
+        response = self._call_api(given_cursor)
+
+        # Then: status code는 200을 리턴한다.
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # And: next_cursor는 10을 리턴한다.
+        self.assertEqual(response.data["next_cursor"], 10)
+        # And: 시작 cursor부터 7개의 issue list를 리턴한다.
+        self.assertEqual(len(response.data["issues"]), 7)
+
+    def test_issue_list_on_empty_issue(self):
+        # Given: 이슈 생성 없이, cursor만 주어진다.
+        given_cursor = 0
+
+        # When: issue list api를 호풀한다.
+        response = self._call_api(given_cursor)
+
+        # Then: status code는 200을 리턴한다
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # And: next_cursor는 0을 리턴한다.
+        self.assertEqual(response.data["next_cursor"], 0)
+        # And: empty list를 리턴한다.
+        self.assertEqual(len(response.data["issues"]), 0)


### PR DESCRIPTION
#149 참고

note list api와 비슷하게 구현했는데
note list api에서는 
`Note.objects.all()[current_cursor : current_cursor + MAX_PRINTABLE_NOTE_COUNT`로 
테이블에서 note들을 전부 가져왔는데

issue list api에서는
```
Issue.objects.intersection(
   Issue.objects.filter(id__gt=current_cursor),
   Issue.objects,filter(id__lte=current_cursor + MAX_PRINTABLE_NOTE_COUNT)
)
```
로 table에서 30개만 가져오도록 구현했습니다.

table에서 전체를 가져오는것 보다는 원하는 만큼만 가져오는것이 더 나을것같다고 생각했습니다.